### PR TITLE
[Feature] Adds Depends on and djin_version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       dry-cli (~> 0.5.0)
       dry-struct (~> 1.3.0)
       dry-validation (~> 1.5.0)
+      vseries (~> 0.1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -14,7 +15,7 @@ GEM
     diff-lcs (1.3)
     dry-cli (0.5.1)
       concurrent-ruby (~> 1.0)
-    dry-configurable (0.11.3)
+    dry-configurable (0.11.5)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.4, >= 0.4.7)
       dry-equalizer (~> 0.2)
@@ -72,6 +73,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.2)
+    vseries (0.1.0)
 
 PLATFORMS
   ruby

--- a/README.md
+++ b/README.md
@@ -44,6 +44,34 @@ test:
 
 ```
 
+You can also set task dependencies with depends_on option:
+
+
+```yaml
+_default_run_options: &default_run_options
+  options: "--rm"
+
+"db:create":
+  docker-compose:
+    service: app
+    run:
+      commands: rake db:create
+      <<: *default_run_options
+
+"db:migrate":
+  docker-compose:
+    service: app
+    run:
+      commands: rake db:migrate
+      <<: *default_run_options
+
+"db:setup":
+  depends_on:
+    - "db:create"
+    - "db:migrate"
+
+```
+
 After that you can run `djin {{task_name}}`, like `djin script` or `djin test`
 
 ## Development
@@ -54,8 +82,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## TODO:
 
-1. Add `depends_on` to run dependent tasks
-2. Adds a `-f` option to load custom djin files
+1. Adds a `-f` option to load custom djin files
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ If you use Rbenv you can install djin only once and create a alias in your .basr
 To use djin first you need to create a djin.yml file:
 
 ```yaml
+djin_version: '0.1.1'
+
 # With a docker image
 script:
   docker:
@@ -48,6 +50,8 @@ You can also set task dependencies with depends_on option:
 
 
 ```yaml
+djin_version: '0.1.1'
+
 _default_run_options: &default_run_options
   options: "--rm"
 

--- a/djin.gemspec
+++ b/djin.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dry-struct", "~> 1.3.0"
   spec.add_dependency "dry-cli", "~> 0.5.0"
   spec.add_dependency "dry-validation", "~> 1.5.0"
+  spec.add_dependency "vseries", "~> 0.1.0"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/djin.yml
+++ b/djin.yml
@@ -1,13 +1,18 @@
+_default_run_options: &default_run_options
+  options: "--rm --entrypoint=''"
+
 test:
   docker-compose:
     service: app
     run:
       commands: "cd /usr/src/djin && rspec"
-      options: "--rm --entrypoint=''"
+      <<: *default_run_options
 sh:
   docker-compose:
     service: app
     run:
       commands: "sh"
-      options: "--rm --entrypoint=''"
+      <<: *default_run_options
+  depends_on:
+    - test
 

--- a/djin.yml
+++ b/djin.yml
@@ -1,3 +1,5 @@
+djin_version: '0.1.1'
+
 _default_run_options: &default_run_options
   options: "--rm --entrypoint=''"
 
@@ -7,6 +9,7 @@ test:
     run:
       commands: "cd /usr/src/djin && rspec"
       <<: *default_run_options
+
 sh:
   docker-compose:
     service: app
@@ -15,4 +18,3 @@ sh:
       <<: *default_run_options
   depends_on:
     - test
-

--- a/lib/djin.rb
+++ b/lib/djin.rb
@@ -3,6 +3,7 @@ require "pathname"
 require "yaml"
 require "dry-struct"
 require "dry-validation"
+require "vseries"
 require "dry/cli"
 require "djin/extensions/hash_extensions"
 require "djin/extensions/custom_predicates"
@@ -27,7 +28,7 @@ module Djin
     @task_repository = TaskRepository.new(tasks)
     CLI.load_tasks!(tasks)
 
-  rescue Djin::Interpreter::InvalidSyntax => ex
+  rescue Djin::Interpreter::InvalidConfigurationError => ex
     abort(ex.message)
   end
 

--- a/lib/djin/entities/task.rb
+++ b/lib/djin/entities/task.rb
@@ -3,7 +3,8 @@ module Djin
     attribute :name, Types::String
     attribute :description, Types::String.optional.default(nil)
     attribute :build_command, Types::String.optional.default(nil)
-    attribute :command, Types::String
+    attribute :command, Types::String.optional.default(nil)
+    attribute :depends_on, Types::Array.of(Types::String).optional.default([].freeze)
 
     def ==(other)
       name == other.name &&

--- a/lib/djin/executor.rb
+++ b/lib/djin/executor.rb
@@ -1,16 +1,28 @@
 module Djin
   class Executor
-   def call(*tasks)
-     tasks.each do |task|
-       run task.build_command if task.build_command
-       run task.command
-     end
-   end
+    def initialize(task_repository: Djin.task_repository)
+      @task_repository = task_repository
+    end
 
-   private
+    def call(*tasks)
+      tasks.each do |task|
+        run_task(task)
+      end
+    end
 
-   def run(command)
-     system command
-   end
+    private
+
+    def run_task(task)
+      @task_repository.find_by_names(task.depends_on).each do |dependent_task|
+        run_task dependent_task
+      end
+
+      run task.build_command if task.build_command
+      run task.command if task.command
+    end
+
+    def run(command)
+      system command
+    end
   end
 end

--- a/lib/djin/interpreter.rb
+++ b/lib/djin/interpreter.rb
@@ -2,19 +2,26 @@ module Djin
   class Interpreter
     using Djin::HashExtensions
 
-    RESERVED_WORDS = %w[_version _default_options].freeze
+    RESERVED_WORDS = %w[djin_version _default_options].freeze
 
-    InvalidSyntax = Class.new(StandardError)
+    InvalidConfigurationError = Class.new(StandardError)
+    MissingVersionError = Class.new(InvalidConfigurationError)
+    VersionNotSupportedError = Class.new(InvalidConfigurationError)
+    InvalidSyntaxError = Class.new(InvalidConfigurationError)
 
     class << self
       def load!(params)
+        version = params['djin_version']
+        raise MissingVersionError, 'Missing djin_version' unless version
+        raise VersionNotSupportedError, "Version #{version} is not supported, use #{Djin::VERSION} or higher" unless version_supported?(version)
+
         tasks_params = params.except(*RESERVED_WORDS).reject { |task| task.start_with?('_') }
         contract = TaskContract.new
 
         tasks_params.map do |task_name, options|
           result = contract.call(options)
 
-          raise InvalidSyntax, result.errors.to_h if result.failure?
+          raise InvalidSyntaxError, result.errors.to_h if result.failure?
 
           command, build_command = build_commands(options, task_name: task_name)
 
@@ -83,6 +90,14 @@ module Djin
         run_command =  run_command.join(' && ') if run_command.is_a?(Array)
 
         [run_command, run_options]
+      end
+
+      def validate_version!(version)
+
+      end
+
+      def version_supported?(version)
+        Vseries::SemanticVersion.new(Djin::VERSION) >= Vseries::SemanticVersion.new(version)
       end
     end
   end

--- a/lib/djin/repositories/task_repository.rb
+++ b/lib/djin/repositories/task_repository.rb
@@ -1,0 +1,17 @@
+class TaskRepository
+  def initialize(tasks = [])
+    @tasks = tasks
+  end
+
+  def add(*tasks)
+    @tasks += tasks
+  end
+
+  def all
+    @tasks
+  end
+
+  def find_by_names(names)
+    @tasks.select { |task| names.include?(task.name) }
+  end
+end

--- a/lib/djin/task_contract.rb
+++ b/lib/djin/task_contract.rb
@@ -32,14 +32,16 @@ module Djin
       optional(:"docker-compose").filled do
         hash(DockerComposeSchema)
       end
+
+      optional(:depends_on).each(:str?)
     end
 
-    rule(:docker, :"docker-compose") do
-      key.failure('docker or docker-compose key is required') unless values[:docker] || values[:"docker-compose"]
+    rule(:docker, :"docker-compose", :depends_on) do
+      key.failure('docker, docker-compose or depends_on key is required') unless values[:docker] || values[:"docker-compose"] || values[:depends_on]
     end
 
-    rule(:'docker-compose',docker: [:image, :build])  do
-      key.failure('image or build param is required for docker tasks') unless values.dig(:docker, :image) || values.dig(:docker, :build) || values[:'docker-compose']
+    rule(:depends_on, :'docker-compose',docker: [:image, :build])  do
+      key.failure('image or build param is required for docker tasks') unless values.dig(:docker, :image) || values.dig(:docker, :build) || values[:'docker-compose'] || values[:depends_on]
     end
 
     rule(docker: :build) do

--- a/spec/lib/djin/task_contract_spec.rb
+++ b/spec/lib/djin/task_contract_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe Djin::TaskContract do
                 'docker-compose' => {
                   'service' => 'app',
                   'run' => {
-                    'commands' => [%q{ruby -e 'puts "Hello"'}],
+                    'commands' => [%q{ruby -e 'puts "Hello"'}, %q{ruby -e 'puts "Hello"'}],
                     'options' => '--rm'
                   }
                 }
@@ -181,6 +181,55 @@ RSpec.describe Djin::TaskContract do
 
         it 'returns the errors for the fields' do
           expect(validation.errors.map(&:path)).to eq([[:'docker-compose', :service], [:'docker-compose', :run]])
+        end
+      end
+    end
+
+    context 'with a depends_on option' do
+      context 'with docker-compose' do
+        let(:task) do
+          {
+            'docker-compose' => {
+              'service' => 'app',
+              'run' => {
+                'commands' => %q{ruby -e 'puts "Hello"'},
+                'options' => '--rm'
+              }
+            },
+            'depends_on' => ['another']
+          }
+        end
+
+        it 'is expect to be valid' do
+          is_expected.to be_success
+        end
+      end
+
+      context 'with docker' do
+        let(:task) do
+          {
+            'docker' => {
+              'image' => 'ruby:2.5',
+              'run' => [%q{ruby -e 'puts "Hello"'}]
+            },
+            'depends_on' => ['another']
+          }
+        end
+
+        it 'is expect to be valid' do
+          is_expected.to be_success
+        end
+      end
+
+      context 'without docker and docker-compose' do
+        let(:task) do
+          {
+            'depends_on' => ['another', 'one', 'bits']
+          }
+        end
+
+        it 'is expect to be valid' do
+          is_expected.to be_success
         end
       end
     end


### PR DESCRIPTION
Adds `depends_on` feature and new required field `djin_version`, eg:

```yaml
djin_version: '0.1.1'
_default_run_options: &default_run_options
  options: "--rm"
"db:create":
  docker-compose:
    service: app
    run:
      commands: rake db:create
      <<: *default_run_options
"db:migrate":
  docker-compose:
    service: app
    run:
      commands: rake db:migrate
      <<: *default_run_options
"db:setup":
  depends_on:
    - "db:create"
    - "db:migrate"
```