### PR TITLE
[FEATURE] Adds description option

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     djin (0.6.1)
       dry-cli (~> 0.6.0)
+      dry-equalizer (~> 0.3.0)
       dry-struct (~> 1.3.0)
       dry-validation (~> 1.5.1)
       mustache (~> 1.1.1)

--- a/djin.gemspec
+++ b/djin.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'dry-cli', '~> 0.6.0'
+  spec.add_dependency 'dry-equalizer', '~> 0.3.0'
   spec.add_dependency 'dry-struct', '~> 1.3.0'
   spec.add_dependency 'dry-validation', '~> 1.5.1'
   spec.add_dependency 'mustache', '~> 1.1.1'

--- a/djin.yml
+++ b/djin.yml
@@ -5,6 +5,7 @@ _default_run_options: &default_run_options
 
 tasks:
   test:
+    description: Runs Specs
     docker-compose:
       service: app
       run:
@@ -12,6 +13,7 @@ tasks:
         <<: *default_run_options
 
   sh:
+    description: Enter app service shell
     docker-compose:
       service: app
       run:

--- a/lib/djin.rb
+++ b/lib/djin.rb
@@ -11,6 +11,7 @@ require 'mustache'
 require 'djin/extensions/hash_extensions'
 require 'djin/entities/types'
 require 'djin/entities/task'
+require 'djin/entities/file_config'
 require 'djin/interpreter/base_command_builder'
 require 'djin/interpreter/docker_command_builder'
 require 'djin/interpreter/docker_compose_command_builder'
@@ -28,10 +29,10 @@ module Djin
   def self.load_tasks!(path = Pathname.getwd.join('djin.yml'))
     abort 'Error: djin.yml not found' unless path.exist?
 
-    djin_config = ConfigLoader.load!(path.read)
+    file_config = ConfigLoader.load!(path.read)
 
     # TODO: Make all tasks be under 'tasks' key, passing only the tasks here
-    tasks = Interpreter.load!(djin_config)
+    tasks = Interpreter.load!(file_config)
 
     @task_repository = TaskRepository.new(tasks)
     CLI.load_tasks!(tasks)

--- a/lib/djin/cli.rb
+++ b/lib/djin/cli.rb
@@ -7,7 +7,7 @@ module Djin
     def self.load_tasks!(tasks)
       tasks.each do |task|
         command = Class.new(Dry::CLI::Command) do
-          desc "Runs: #{task.command}"
+          desc task.description
 
           define_method(:task) { task }
 

--- a/lib/djin/entities/file_config.rb
+++ b/lib/djin/entities/file_config.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Djin
+  class FileConfig < Dry::Struct
+    attribute :djin_version, Types::String
+    attribute :variables, Types::Hash.optional.default({}.freeze)
+    attribute :tasks, Types::Hash
+    attribute :raw_tasks, Types::Hash
+    # TODO: Add env and args
+
+    include Dry::Equalizer(:djin_version, :variables, :tasks, :raw_tasks)
+
+    def version_supported?
+      Vseries::SemanticVersion.new(Djin::VERSION) >= Vseries::SemanticVersion.new(djin_version)
+    end
+  end
+end

--- a/lib/djin/entities/task.rb
+++ b/lib/djin/entities/task.rb
@@ -6,12 +6,9 @@ module Djin
     attribute :description, Types::String.optional.default(nil)
     attribute :build_command, Types::String.optional.default(nil)
     attribute :command, Types::String.optional.default(nil)
+    attribute :raw_command, Types::String.optional.default(nil)
     attribute :depends_on, Types::Array.of(Types::String).optional.default([].freeze)
 
-    def ==(other)
-      name == other.name &&
-        command == other.command &&
-        build_command == other.build_command
-    end
+    include Dry::Equalizer(:name, :command, :build_command)
   end
 end

--- a/lib/djin/interpreter.rb
+++ b/lib/djin/interpreter.rb
@@ -12,20 +12,24 @@ module Djin
     InvalidSyntaxError = Class.new(InvalidConfigurationError)
 
     class << self
-      def load!(tasks_params)
+      def load!(file_config)
         contract = TaskContract.new
 
-        tasks_params.map do |task_name, options|
+        file_config.tasks.map do |task_name, options|
           result = contract.call(options)
 
           raise InvalidSyntaxError, { task_name.to_sym => result.errors.to_h } if result.failure?
 
           command, build_command = build_commands(options, task_name: task_name)
 
+          raw_command, = build_commands(file_config.raw_tasks[task_name], task_name: task_name)
+
           task_params = {
             name: task_name,
             build_command: build_command,
+            description: options['description'] || "Runs: #{raw_command}",
             command: command,
+            raw_command: raw_command,
             depends_on: options['depends_on']
           }.compact
 


### PR DESCRIPTION
  * [FEATURE] - Adds custom description option for tasks, eg:

  ```
  tasks:
    test:
      description: Runs Specs
      docker-compose:
        service: app
        run: bundle exec rspec
  ```

  * [PATCH] - Default description for Mustache interpolation options

    Now {{args}}, {{some_variable}} is show and not rendered in default
    description.