### PR TITLE
  [FEATURE] Adds aliases option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,13 @@ tasks:
 
   # Using a docker-compose service
   test:
-  docker-compose:
-    service: app
-    run:
-      commands: rspec
-      options: "--rm"
+    docker-compose:
+      service: app
+      run:
+        commands: rspec
+        options: "--rm"
+    aliases: # Optional Array of strings
+      - rspec
 ```
 
 You can also set task dependencies with depends_on option:
@@ -172,6 +174,8 @@ tasks:
       run:
         commands: rubocop {{args}}
         <<: *default_run_options
+    aliases:
+      - lint
 
 ```
 

--- a/djin.yml
+++ b/djin.yml
@@ -11,6 +11,8 @@ tasks:
       run:
         commands: "cd /usr/src/djin && rspec {{args}}"
         <<: *default_run_options
+    aliases:
+      - rspec
 
   sh:
     description: Enter app service shell

--- a/lib/djin/cli.rb
+++ b/lib/djin/cli.rb
@@ -16,7 +16,7 @@ module Djin
           end
         end
 
-        register task.name, command
+        register(task.name, command, aliases: task.aliases)
       end
     end
 

--- a/lib/djin/entities/task.rb
+++ b/lib/djin/entities/task.rb
@@ -7,6 +7,7 @@ module Djin
     attribute :build_command, Types::String.optional.default(nil)
     attribute :command, Types::String.optional.default(nil)
     attribute :raw_command, Types::String.optional.default(nil)
+    attribute :aliases, Types::Array.of(Types::String).optional.default([].freeze)
     attribute :depends_on, Types::Array.of(Types::String).optional.default([].freeze)
 
     include Dry::Equalizer(:name, :command, :build_command)

--- a/lib/djin/interpreter.rb
+++ b/lib/djin/interpreter.rb
@@ -30,6 +30,7 @@ module Djin
             description: options['description'] || "Runs: #{raw_command}",
             command: command,
             raw_command: raw_command,
+            aliases: options['aliases'],
             depends_on: options['depends_on']
           }.compact
 

--- a/lib/djin/task_contract.rb
+++ b/lib/djin/task_contract.rb
@@ -49,6 +49,7 @@ module Djin
         hash(LocalSchema)
       end
 
+      optional(:aliases).each(:str?)
       optional(:depends_on).each(:str?)
     end
 

--- a/spec/lib/djin/cli_spec.rb
+++ b/spec/lib/djin/cli_spec.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe Djin::CLI do
+  xdescribe '.load_tasks' do
+    it 'load the tasks' do
+    end
+  end
+
   describe described_class::Version do
     let(:instance) { described_class.new }
 

--- a/spec/lib/djin/config_loader_spec.rb
+++ b/spec/lib/djin/config_loader_spec.rb
@@ -631,6 +631,39 @@ RSpec.describe Djin::ConfigLoader do
       end
     end
 
+    context 'with aliases' do
+      let(:config) do
+        {
+          'djin_version' => djin_version,
+          'tasks' => {
+            'default' => {
+              'docker' => {
+                'image' => 'ruby:2.5',
+                'run' => [%q(ruby -e 'puts "Test"')]
+              },
+              'aliases' => ['theone']
+            }
+          }
+        }.to_yaml
+      end
+
+      let(:expected_tasks) do
+        {
+          'default' => {
+            'docker' => {
+              'image' => 'ruby:2.5',
+              'run' => [%q(ruby -e 'puts "Test"')]
+            },
+            'aliases' => ['theone']
+          }
+        }
+      end
+
+      it 'returns config tasks' do
+        is_expected.to eq(expected_file_config)
+      end
+    end
+
     context 'without djin_version' do
       let(:config) do
         {


### PR DESCRIPTION
  ```
  ...
    tasks:
      test:
        docker-compose:
          service: app
          run:
            commands: rspec
            options: "--rm"
        aliases:
          - rspec

  ```

  Run's with `djin test` or `djin rspec`