### PR TITLE
  [FIX] Enable ssh and file repositories in include option

### DIFF
--- a/lib/djin/include_contract.rb
+++ b/lib/djin/include_contract.rb
@@ -5,6 +5,8 @@ module Djin
     using Djin::ObjectExtensions
 
     GIT_URI_REGEXP = Regexp.new('(\w+://)(.+@)*([\w\d\.]+)(:[\d]+){0,1}/*(.*)')
+    GIT_SSH_REGEXP = Regexp.new('(.+@)+([\w\d\.]+):(.*)')
+    GIT_FILE_REGEXP = Regexp.new('file://(.*)')
 
     ContextSchema = Dry::Schema.Params do
       optional(:variables).filled(:hash)
@@ -21,9 +23,17 @@ module Djin
     end
 
     rule(:git) do
-      key.failure("Invalid git uri in: #{value}") if value.present? && !GIT_URI_REGEXP.match?(value)
+      key.failure("Invalid git uri in: #{value}") if value.present? && !valid_git_repository_path?(value)
     end
 
     # TODO: Add more validations to file and to restricted unespected keys
+    #
+    private
+
+    def valid_git_repository_path?(path)
+      [GIT_URI_REGEXP,
+       GIT_SSH_REGEXP,
+       GIT_FILE_REGEXP].any? { |regexp| regexp.match?(path) }
+    end
   end
 end

--- a/spec/features/remote_config_spec.rb
+++ b/spec/features/remote_config_spec.rb
@@ -18,10 +18,6 @@ RSpec.describe 'remote-config subcommand', type: :feature do
     end
 
     context 'when remote config doenst exists' do
-      before do
-        repo.delete
-      end
-
       it 'clone repository to remote folder' do
         expect {
           _, err = fetch

--- a/spec/lib/djin/include_contract_spec.rb
+++ b/spec/lib/djin/include_contract_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Djin::IncludeContract do
       end
     end
 
-    context 'with a remotw include' do
+    context 'with a remote include' do
       context 'with valid params' do
         let(:include_params) do
           {
@@ -65,12 +65,12 @@ RSpec.describe Djin::IncludeContract do
           is_expected.to be_success
         end
 
-        context 'with invalid params' do
+        context 'with ssh path' do
           let(:include_params) do
             {
-              'file' => [],
-              'git' => 'opa',
-              'version' => {},
+              'file' => 'my_file',
+              'git' => 'git@bitbucket.org:vagas/djin_vagas.git',
+              'version' => '9.10.0',
               'context' => {
                 'variables' => {
                   'namespace' => 'host1',
@@ -81,13 +81,55 @@ RSpec.describe Djin::IncludeContract do
             }
           end
 
-          it 'is expected to be invalid' do
-            is_expected.to be_a_failure
+          it 'is expect to be valid' do
+            is_expected.to be_success
+          end
+        end
+
+        context 'with a file path' do
+          let(:include_params) do
+            {
+              'file' => 'my_file',
+              'git' => 'file:///path/to/repo.git/',
+              'version' => '9.80.109',
+              'context' => {
+                'variables' => {
+                  'namespace' => 'host1',
+                  'host' => 'host1.com',
+                  'ssh_user' => 'my_user'
+                }
+              }
+            }
           end
 
-          it 'returns the errors for the fields' do
-            expect(validation.errors.map(&:path)).to eq([%i[file], %i[version], %i[git]])
+          it 'is expect to be valid' do
+            is_expected.to be_success
           end
+        end
+      end
+
+      context 'with invalid params' do
+        let(:include_params) do
+          {
+            'file' => [],
+            'git' => 'opa',
+            'version' => {},
+            'context' => {
+              'variables' => {
+                'namespace' => 'host1',
+                'host' => 'host1.com',
+                'ssh_user' => 'my_user'
+              }
+            }
+          }
+        end
+
+        it 'is expected to be invalid' do
+          is_expected.to be_a_failure
+        end
+
+        it 'returns the errors for the fields' do
+          expect(validation.errors.map(&:path)).to eq([%i[file], %i[version], %i[git]])
         end
       end
     end


### PR DESCRIPTION
  Before the validation are only accepting uri paths for git repositories