### PR TITLE
  [FIX] Version Error Message

### DIFF
--- a/lib/djin/config_loader.rb
+++ b/lib/djin/config_loader.rb
@@ -161,7 +161,7 @@ module Djin
 
       return if file_config.version_supported?
 
-      raise VersionNotSupportedError, "Version #{version} is not supported, use #{Djin::VERSION} or higher"
+      raise VersionNotSupportedError, "Version #{version} is not supported, the current version is #{Djin::VERSION}"
     end
 
     def validate_missing_config!


### PR DESCRIPTION
  Changes "Version {{version}} is not supported, use {{current_version}} or higher" to
  "Version {{version}} is not supported, the current version is {{current_version}}"